### PR TITLE
Save one byte: xor rax,rax -> xor eax,eax

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ after_argv:
         mov rsi, rdi
 
         ; Zero-out RAX and set envp by means of CDQ instruction onto RDX
-        xor rax, rax
+        xor eax, eax
         cdq
 
         ; Push the last NULL argument - argv[3]

--- a/polyglot.asm
+++ b/polyglot.asm
@@ -25,7 +25,7 @@ after_argv:
         mov rsi, rdi
 
         ; Zero-out RAX and set envp by means of CDQ instruction onto RDX
-        xor rax, rax
+        xor eax, eax
         cdq
 
         ; Push the last NULL argument - argv[3]


### PR DESCRIPTION
`xor eax,eax` accomplishes the same as `xor rax,rax` but avoids one byte of REX.W prefix.

So now the polyglot is 69 bytes<sup>nice ( ͡° ͜ʖ ͡°)</sup>.