### PR TITLE
Save one byte: "R4=" -> "j="

### DIFF
--- a/polyglot.asm
+++ b/polyglot.asm
@@ -4,7 +4,7 @@
 EXECVE_SYSCALL_NUM EQU 0x3B
 
         ; Make a dummy variable for bash
-        db 'R4='                        ; Interpreted as PUSH RDX; XOR AL, 0x3D
+        db 'j='                         ; Interpreted as PUSH 0x3d
 
         ; Jump over argv
         call after_argv


### PR DESCRIPTION
Turns out that PUSH imm8 is encoded as `6A ib` and 0x6A is ASCII `j`, so you can start your polyglot with `j=` instead of `R4=`, saving one byte. <sub>Yeah, I really have nothing better to do on my lunch breaks than think about golfing x86 asm :')</sub>

Found with a simple modification to the Capstone script from your README:

```python
from capstone import *

def f(c):
    # One char followed by "=" plus the bytes you already have
    code = c.encode() + b'=\xe8\x19\x00\x00\x00\x3b\x2f\x62\x69\x6e\x2f\x63\x75\x72\x6c'
    md = Cs(CS_ARCH_X86, CS_MODE_64)
    print(f'=== {c} ===')
    for i in md.disasm(code, 0):
        print("0x%x:\t%s\t%s" %(i.address, i.mnemonic, i.op_str))

legals = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_'
for i in legals:
    f(i)
```

Yields:

```none
=== j ===
0x0:	push	0x3d
0x2:	call	0x20
0x7:	cmp	ebp, dword ptr [rdi]
```

I think as per BGGP rules you are allowed to update your solution once. So maybe wait until near the end if you wanna see if some other bytes can be shaved off? Though I doubt it at this point.

P.S. shouldn't all the "bash" mentions in the `.asm` say "sh" instead?